### PR TITLE
统一商品分发前端视觉风格

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,14 +1,20 @@
 import { BrowserRouter, Routes, Route, Link, useLocation } from 'react-router-dom';
-import { Zap, LayoutDashboard, Package, ListTodo, Settings } from 'lucide-react';
+import { Blocks, Image as ImageIcon, LayoutDashboard, LayoutGrid, ListTodo, Package, Settings } from 'lucide-react';
 import Dashboard from './pages/Dashboard';
 import Products from './pages/Products';
 import Tasks from './pages/Tasks';
 import Platforms from './pages/Platforms';
 
+const appNavs = [
+  { href: 'http://127.0.0.1:3100', name: '工作台', icon: LayoutGrid, active: false },
+  { href: 'http://127.0.0.1:3200', name: '图片优化', icon: ImageIcon, active: false },
+  { href: 'http://127.0.0.1:5173', name: '商品分发', icon: Blocks, active: true },
+];
+
 const navs = [
+  { path: '/', name: '任务管理', icon: ListTodo },
   { path: '/dashboard', name: '仪表盘', icon: LayoutDashboard },
   { path: '/products', name: '商品管理', icon: Package },
-  { path: '/', name: '任务管理', icon: ListTodo },
   { path: '/platforms', name: '平台管理', icon: Settings },
 ];
 
@@ -24,40 +30,78 @@ function Layout() {
   const headerTitle = PAGE_TITLES[location.pathname] || '任务调度中心';
 
   return (
-    <>
-      <aside className="w-64 bg-white border-r border-gray-200 flex flex-col z-10">
-        <div className="h-16 flex items-center px-6 font-bold text-xl border-b border-gray-200 gap-2">
-          <Zap className="text-blue-600" size={24} />
-          商品分发中枢
-        </div>
-        <nav className="flex-1 p-4 space-y-2">
-          {navs.map((nav) => {
-            const isActive = location.pathname === nav.path;
-            const Icon = nav.icon;
-            return (
-              <Link key={nav.path} to={nav.path} className={`w-full flex items-center gap-3 px-4 py-2.5 rounded-lg text-sm transition-colors ${
-                isActive 
-                  ? 'bg-gray-100 font-semibold text-slate-900' 
-                  : 'font-medium text-gray-500 hover:bg-gray-50'
-              }`}>
-                <Icon size={20} /> {nav.name}
-              </Link>
-            );
-          })}
-        </nav>
-      </aside>
-
-      <main className="flex-1 flex flex-col h-screen overflow-hidden relative bg-gray-50">
-        <header className="h-16 bg-white border-b border-gray-200 flex items-center justify-between px-6 shrink-0">
-          <h2 className="text-lg font-semibold">{headerTitle}</h2>
-          <div className="flex items-center gap-4">
-             <div className="text-sm text-gray-500 flex items-center">
-                系统调度正常运行中 <span className="inline-block w-2 h-2 bg-green-500 rounded-full animate-pulse ml-2"></span>
-             </div>
+    <div className="min-h-screen bg-[radial-gradient(circle_at_12%_8%,rgba(65,88,208,0.16),transparent_26%),radial-gradient(circle_at_88%_4%,rgba(200,80,192,0.14),transparent_28%),linear-gradient(135deg,#f0f2ff,#eef3ff_42%,#f6f4ff)] text-neutral-900">
+      <header className="sticky top-0 z-30 border-b border-[rgba(199,210,254,0.5)] bg-white/85 backdrop-blur-sm">
+        <div className="mx-auto flex h-[62px] max-w-7xl items-center justify-between px-5">
+          <div className="flex min-w-[260px] items-center gap-2">
+            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-[#4158d0] to-[#c850c0] text-sm font-bold text-white">
+              叮
+            </div>
+            <div className="text-[17px] font-bold dd-gradient-text">巨浪童装AI</div>
+            <span className="ml-1 rounded bg-[rgba(200,80,192,0.1)] px-1.5 py-0.5 text-[11px] font-semibold text-[#c850c0]">BETA</span>
           </div>
-        </header>
-        
-        <div className="flex-1 overflow-y-auto p-6">
+
+          <nav className="flex items-center gap-2 rounded-full border border-[rgba(199,210,254,0.72)] bg-white/80 px-2 py-2 shadow-[0_8px_22px_rgba(65,88,208,0.08)] backdrop-blur">
+            {appNavs.map((item) => {
+              const Icon = item.icon;
+              return (
+                <a
+                  key={item.name}
+                  href={item.href}
+                  className={`dd-nav-button gap-2 transition ${
+                    item.active
+                      ? 'bg-gradient-to-r from-[#4158d0] to-[#c850c0] text-white shadow-[0_6px_18px_rgba(117,106,255,0.28)]'
+                      : 'text-neutral-600 hover:bg-[rgba(65,88,208,0.06)]'
+                  }`}
+                >
+                  <Icon className="h-4 w-4" />
+                  {item.name}
+                </a>
+              );
+            })}
+          </nav>
+
+          <div className="flex min-w-[260px] items-center justify-end text-sm text-neutral-500">
+            系统调度正常运行中 <span className="ml-2 inline-block h-2 w-2 animate-pulse rounded-full bg-green-500" />
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-7xl px-5 py-6">
+        <section className="dd-panel relative mb-5 overflow-hidden px-6 py-5">
+          <div className="absolute right-[-40px] top-[-70px] h-36 w-36 rounded-full bg-[rgba(200,80,192,0.12)] blur-3xl" />
+          <div className="relative flex flex-col gap-5 xl:flex-row xl:items-center xl:justify-between">
+            <div className="flex shrink-0 items-center gap-4 pr-6 xl:border-r xl:border-[rgba(199,210,254,0.62)]">
+              <div className="h-12 w-1.5 rounded-full bg-gradient-to-b from-[#4158d0] to-[#c850c0]" />
+              <div>
+                <div className="whitespace-nowrap text-2xl font-black leading-none tracking-tight text-neutral-900">{headerTitle}</div>
+                <div className="mt-2 whitespace-nowrap text-sm font-medium leading-none text-neutral-500">商品分发内部功能导航</div>
+              </div>
+            </div>
+            <nav className="flex flex-wrap items-center gap-2 xl:justify-end">
+              {navs.map((nav) => {
+                const isActive = location.pathname === nav.path;
+                const Icon = nav.icon;
+                return (
+                  <Link
+                    key={nav.path}
+                    to={nav.path}
+                    className={`dd-nav-button gap-2 transition ${
+                      isActive
+                        ? 'bg-gradient-to-r from-[#4158d0] to-[#c850c0] text-white shadow-[0_6px_18px_rgba(117,106,255,0.24)]'
+                        : 'border border-[rgba(199,210,254,0.72)] bg-white/75 text-neutral-600 hover:bg-[rgba(65,88,208,0.06)]'
+                    }`}
+                  >
+                    <Icon className="h-4 w-4" />
+                    {nav.name}
+                  </Link>
+                );
+              })}
+            </nav>
+          </div>
+        </section>
+
+        <div className="pb-8">
           <Routes>
             <Route path="/" element={<Tasks />} />
             <Route path="/dashboard" element={<Dashboard />} />
@@ -66,7 +110,7 @@ function Layout() {
           </Routes>
         </div>
       </main>
-    </>
+    </div>
   );
 }
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -2,18 +2,239 @@
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
 
-body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-  background-color: #f9fafb; /* 对应 tailwind 的 bg-gray-50 */
-  color: #0f172a; /* 对应 text-slate-900 */
+:root {
+  --dd-primary: #4158d0;
+  --dd-secondary: #c850c0;
+  --dd-accent: #756aff;
+  --dd-gradient: linear-gradient(135deg,#4158d0,#c850c0);
 }
 
-/* 关键：让 React 根节点行为和原来 HTML 的 body 一模一样 */
+body {
+  font-family: PingFangSC, "PingFang SC", "Microsoft YaHei", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 12% 8%, rgba(65,88,208,.16), transparent 26%),
+    radial-gradient(circle at 88% 4%, rgba(200,80,192,.14), transparent 28%),
+    linear-gradient(135deg,#f0f2ff,#eef3ff 42%,#f6f4ff);
+  color: #0f172a;
+}
+
 #root {
-  display: flex;
-  height: 100vh;
+  min-height: 100vh;
   width: 100vw;
+}
+
+.dd-gradient-text {
+  background: var(--dd-gradient);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.dd-panel {
+  background: linear-gradient(135deg,rgba(255,255,255,.88),rgba(250,248,255,.78));
+  border: 1px solid rgba(199,210,254,.68);
+  border-radius: 24px;
+  box-shadow: 0 18px 44px rgba(65,88,208,.1);
+  backdrop-filter: blur(12px);
+}
+
+.dd-card {
+  background: linear-gradient(135deg,rgba(255,255,255,.94),rgba(250,248,255,.84));
+  border: 1px solid rgba(199,210,254,.66);
+  border-radius: 20px;
+  box-shadow: 0 10px 28px rgba(65,88,208,.08);
+}
+
+.dd-button {
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  height: 40px !important;
+  min-height: 40px !important;
+  min-width: 112px !important;
+  padding: 0 20px !important;
+  background: var(--dd-gradient);
+  color: #fff;
+  border-radius: 999px !important;
+  font-size: 14px !important;
+  font-weight: 800;
+  line-height: 1 !important;
+  white-space: nowrap !important;
+  box-shadow: 0 6px 18px rgba(117,106,255,.28);
+}
+
+.dd-button:hover {
+  filter: brightness(1.08);
+}
+
+.dd-button-soft {
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  height: 40px !important;
+  min-height: 40px !important;
+  min-width: 112px !important;
+  padding: 0 20px !important;
+  background: rgba(255,255,255,.9);
+  color: #475569;
+  border: 1px solid rgba(199,210,254,.7);
+  border-radius: 999px !important;
+  font-size: 14px !important;
+  font-weight: 800;
+  line-height: 1 !important;
+  white-space: nowrap !important;
+  box-shadow: 0 4px 14px rgba(65,88,208,.05);
+}
+
+.dd-button-soft:hover {
+  background: rgba(65,88,208,.06);
+  color: #4158d0;
+}
+
+.dd-icon-button {
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  width: 40px !important;
+  height: 40px !important;
+  min-width: 40px !important;
+  padding: 0 !important;
+  border-radius: 999px !important;
+}
+
+.dd-nav-button {
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  height: 40px !important;
+  min-height: 40px !important;
+  padding: 0 18px !important;
+  border-radius: 999px !important;
+  font-size: 14px !important;
+  font-weight: 800 !important;
+  line-height: 1 !important;
+  white-space: nowrap !important;
+}
+
+.dd-close-button {
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  width: 36px !important;
+  height: 36px !important;
+  min-width: 36px !important;
+  padding: 0 !important;
+  border-radius: 999px !important;
+  background: rgba(255,255,255,.72);
+  color: rgba(117,106,255,.78);
+  font-size: 20px !important;
+  font-weight: 700 !important;
+}
+
+.dd-close-button:hover {
+  color: #4158d0;
+  background: rgba(65,88,208,.08);
+}
+
+.dd-input,
+.dd-select {
+  height: 40px;
+  border-radius: 999px;
+  border: 1px solid rgba(199,210,254,.72);
+  background: rgba(255,255,255,.9);
+  color: #334155;
+  outline: none;
+  box-shadow: 0 4px 14px rgba(65,88,208,.04);
+  transition: border-color .18s ease, box-shadow .18s ease, background .18s ease;
+}
+
+.dd-input:focus,
+.dd-select:focus {
+  border-color: rgba(117,106,255,.72);
+  background: #fff;
+  box-shadow: 0 0 0 4px rgba(117,106,255,.12);
+}
+
+.dd-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 700;
+  border: 1px solid transparent;
+}
+
+.dd-badge-success { background: rgba(16,185,129,.1); color: #047857; border-color: rgba(16,185,129,.18); }
+.dd-badge-danger { background: rgba(239,68,68,.1); color: #b91c1c; border-color: rgba(239,68,68,.18); }
+.dd-badge-info { background: rgba(65,88,208,.1); color: #4158d0; border-color: rgba(65,88,208,.18); }
+.dd-badge-warning { background: rgba(245,158,11,.12); color: #b45309; border-color: rgba(245,158,11,.2); }
+.dd-badge-muted { background: rgba(100,116,139,.1); color: #64748b; border-color: rgba(100,116,139,.16); }
+.dd-badge-gradient { background: linear-gradient(135deg,rgba(65,88,208,.12),rgba(200,80,192,.12)); color: #4158d0; border-color: rgba(199,210,254,.7); }
+
+.dd-table {
   overflow: hidden;
+  border-radius: 22px;
+  border: 1px solid rgba(199,210,254,.68);
+  background: linear-gradient(135deg,rgba(255,255,255,.92),rgba(250,248,255,.78));
+  box-shadow: 0 16px 38px rgba(65,88,208,.09);
+}
+
+.dd-table table { width: 100%; border-collapse: collapse; }
+.dd-table thead { background: linear-gradient(90deg,rgba(65,88,208,.08),rgba(200,80,192,.07)); color: #475569; }
+.dd-table th { padding: 13px 16px; font-size: 12px; font-weight: 800; text-align: left; }
+.dd-table td { padding: 14px 16px; border-top: 1px solid rgba(226,232,240,.85); color: #334155; }
+.dd-table tbody tr { transition: background .18s ease; }
+.dd-table tbody tr:hover { background: rgba(65,88,208,.035); }
+
+.dd-tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px;
+  border-radius: 999px;
+  border: 1px solid rgba(199,210,254,.68);
+  background: rgba(255,255,255,.82);
+  box-shadow: 0 8px 22px rgba(65,88,208,.06);
+}
+
+.dd-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  height: 36px;
+  border-radius: 999px;
+  padding: 0 14px;
+  font-size: 14px;
+  font-weight: 700;
+  color: #64748b;
+  transition: background .18s ease, color .18s ease, box-shadow .18s ease;
+}
+
+.dd-tab-active {
+  background: var(--dd-gradient);
+  color: #fff;
+  box-shadow: 0 6px 18px rgba(117,106,255,.26);
+}
+
+.dd-empty {
+  border-radius: 20px;
+  border: 1px dashed rgba(199,210,254,.9);
+  background: linear-gradient(135deg,rgba(255,255,255,.74),rgba(246,244,255,.86));
+  color: #64748b;
+}
+
+.dd-modal {
+  border-radius: 24px;
+  border: 1px solid rgba(199,210,254,.68);
+  background: rgba(255,255,255,.96);
+  box-shadow: 0 24px 70px rgba(65,88,208,.16);
+}
+
+.dd-overlay {
+  background: rgba(15,23,42,.36);
+  backdrop-filter: blur(6px);
 }
 
 ::-webkit-scrollbar { width: 6px; height: 6px; }

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -52,21 +52,19 @@ export default function Dashboard() {
   return (
     <div className="space-y-6">
       {/* Stats */}
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
         {cards.map((c) => (
-          <div
-            key={c.label}
-            className={`p-5 rounded-xl border shadow-sm hover:shadow transition-shadow ${
-              c.highlight ? 'bg-blue-50/80 border-blue-200' : 'bg-white border-gray-200'
-            }`}
-          >
-            <div className={`flex justify-between items-center mb-2 ${c.highlight ? 'text-blue-600' : 'text-gray-500'}`}>
-              <span className="text-sm font-medium">{c.label}</span>
-              <c.icon size={16} />
+          <div key={c.label} className="dd-card relative overflow-hidden p-5 transition hover:-translate-y-0.5 hover:shadow-[0_12px_30px_rgba(65,88,208,0.12)]">
+            <div className="absolute right-0 top-0 h-20 w-20 rounded-bl-[44px] bg-gradient-to-br from-[rgba(65,88,208,0.13)] to-[rgba(200,80,192,0.13)]" />
+            <div className="relative mb-3 flex items-center justify-between text-neutral-500">
+              <span className="text-sm font-semibold">{c.label}</span>
+              <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-[rgba(65,88,208,0.12)] to-[rgba(200,80,192,0.12)] text-[#4158d0]">
+                <c.icon size={17} />
+              </span>
             </div>
-            <div className={`text-2xl font-bold ${c.highlight ? 'text-blue-700' : ''}`}>{c.value}</div>
+            <div className="relative text-3xl font-black text-neutral-900">{c.value}</div>
             {c.highlight && stats.pendingTasks > 0 && (
-              <div className="text-xs mt-1 flex items-center gap-1 text-blue-600">
+              <div className="relative mt-2 flex items-center gap-1 text-xs font-semibold text-[#4158d0]">
                 <Loader2 size={12} className="animate-spin" /> 后台排队执行中
               </div>
             )}
@@ -81,13 +79,13 @@ export default function Dashboard() {
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Timeline — real data */}
-        <div className="bg-white rounded-xl border border-gray-200 shadow-sm lg:col-span-2 flex flex-col">
-          <div className="p-5 border-b border-gray-100 font-semibold flex items-center gap-2">
-            <Activity size={16} className="text-gray-400" /> 近期任务活动
+        <div className="dd-panel flex flex-col lg:col-span-2">
+          <div className="flex items-center gap-2 border-b border-[rgba(199,210,254,0.55)] p-5 font-bold text-neutral-800">
+            <Activity size={16} className="text-[#756aff]" /> 近期任务活动
           </div>
-          <div className="p-6 ml-3 border-l-2 border-gray-100 relative space-y-7 flex-1">
+          <div className="relative ml-3 flex-1 space-y-7 border-l-2 border-[rgba(199,210,254,0.55)] p-6">
             {activities.length === 0 && (
-              <div className="text-sm text-gray-400 pl-6">暂无任务记录</div>
+              <div className="dd-empty ml-3 p-6 text-center text-sm">暂无任务记录</div>
             )}
             {activities.map((a) => {
               const isRunning = a.status === 'running' || a.status === 'pending';
@@ -111,15 +109,15 @@ export default function Dashboard() {
                   {a.status === 'running' && '，正在执行中...'}
                   {a.status === 'pending' && '，等待执行...'}
                   {a.status === 'done' && (
-                    <span className={`ml-1 px-1.5 rounded text-xs ${a.failed_items > 0 ? 'text-yellow-700 bg-yellow-50' : 'text-green-600 bg-green-50'}`}>
-                      (成功 {a.success_items} / 失败 {a.failed_items})
+                    <span className={`dd-badge ml-1 px-2 py-0.5 text-[11px] ${a.failed_items > 0 ? 'dd-badge-warning' : 'dd-badge-success'}`}>
+                      成功 {a.success_items} / 失败 {a.failed_items}
                     </span>
                   )}
                   {a.status === 'failed' && (
-                    <span className="ml-1 text-red-600 text-xs bg-red-50 px-1.5 rounded">执行失败</span>
+                    <span className="dd-badge dd-badge-danger ml-1 px-2 py-0.5 text-[11px]">执行失败</span>
                   )}
                   {a.status === 'cancelled' && (
-                    <span className="ml-1 text-gray-500 text-xs bg-gray-100 px-1.5 rounded">已取消</span>
+                    <span className="dd-badge dd-badge-muted ml-1 px-2 py-0.5 text-[11px]">已取消</span>
                   )}
                   {hasErrors && !isExpanded && (
                     <span className="ml-1 text-red-500 text-xs cursor-pointer hover:underline">({a.errors.length} 条错误，点击查看)</span>
@@ -140,27 +138,27 @@ export default function Dashboard() {
         </div>
 
         {/* Platform status */}
-        <div className="bg-white rounded-xl border border-gray-200 shadow-sm">
-          <div className="p-5 border-b border-gray-100 font-semibold flex items-center gap-2">
-            <ShieldCheck size={16} className="text-gray-400" /> 各平台状态一览
+        <div className="dd-panel overflow-hidden">
+          <div className="flex items-center gap-2 border-b border-[rgba(199,210,254,0.55)] p-5 font-bold text-neutral-800">
+            <ShieldCheck size={16} className="text-[#756aff]" /> 各平台状态一览
           </div>
-          <div className="p-5 space-y-5">
+          <div className="space-y-4 p-5">
             {platforms.map((p) => {
               const Icon = platformIcons[p.code] || ShoppingBag;
               return (
-                <div key={p.code} className="flex items-center justify-between">
-                  <span className="text-sm font-medium flex items-center gap-2">
-                    <div className={`w-6 h-6 rounded flex items-center justify-center ${p.login_active ? 'bg-green-100' : 'bg-red-50'}`}>
-                      <Icon size={14} className={p.login_active ? 'text-green-600' : 'text-red-500'} />
+                <div key={p.code} className="flex items-center justify-between rounded-2xl border border-[rgba(199,210,254,0.55)] bg-white/70 p-3">
+                  <span className="flex items-center gap-2 text-sm font-semibold text-neutral-700">
+                    <div className={`flex h-8 w-8 items-center justify-center rounded-xl ${p.login_active ? 'bg-green-100' : 'bg-red-50'}`}>
+                      <Icon size={15} className={p.login_active ? 'text-green-600' : 'text-red-500'} />
                     </div>
                     {p.name}
                   </span>
                   {p.login_active ? (
-                    <span className="px-2 py-1 bg-green-50 border border-green-100 text-green-700 rounded text-[11px] font-medium flex items-center gap-1">
+                    <span className="dd-badge dd-badge-success text-[11px]">
                       <CheckCircle2 size={12} /> 已登录
                     </span>
                   ) : (
-                    <span className="px-2 py-1 bg-red-50 border border-red-100 text-red-600 rounded text-[11px] font-medium flex items-center gap-1">
+                    <span className="dd-badge dd-badge-danger text-[11px]">
                       <XCircle size={12} /> 未登录
                     </span>
                   )}
@@ -178,8 +176,8 @@ function TimelineItem({ time, color, pulse, clickable, onClick, children }: { ti
   return (
     <div className={`pl-6 relative ${clickable ? 'cursor-pointer' : ''}`} onClick={clickable ? onClick : undefined}>
       <span className={`absolute -left-[5px] top-1.5 w-2.5 h-2.5 rounded-full ${color} ring-4 ring-white ${pulse ? 'animate-pulse' : ''}`} />
-      <div className="text-sm font-medium text-gray-400 mb-1">{time}</div>
-      <div className="text-sm text-gray-700">{children}</div>
+      <div className="mb-1 text-sm font-semibold text-[#756aff]/70">{time}</div>
+      <div className="text-sm text-neutral-700">{children}</div>
     </div>
   );
 }
@@ -189,11 +187,11 @@ function ErrorBanner({ errors }: { errors: { taskId: number; type: string; time:
   if (collapsed) return null;
 
   return (
-    <div className="bg-red-50 border border-red-200 rounded-xl px-4 py-3 relative flex items-center justify-between">
-      <div className="flex items-center gap-2 text-red-700 font-semibold text-sm">
+    <div className="relative flex items-center justify-between rounded-2xl border border-red-200 bg-red-50/90 px-4 py-3 shadow-[0_8px_24px_rgba(239,68,68,0.08)]">
+      <div className="flex items-center gap-2 text-sm font-semibold text-red-700">
         <AlertTriangle size={16} /> 最近任务中有 {errors.length} 条错误
       </div>
-      <button onClick={() => setCollapsed(true)} className="text-red-300 hover:text-red-500">
+      <button onClick={() => setCollapsed(true)} className="dd-close-button !h-8 !min-w-8 !w-8 text-red-300 hover:text-red-500">
         <XIcon size={16} />
       </button>
     </div>

--- a/web/src/pages/Platforms.tsx
+++ b/web/src/pages/Platforms.tsx
@@ -12,13 +12,13 @@ const PLATFORM_ICONS: Record<string, typeof MessageCircle> = {
 };
 
 const ICON_COLORS: Record<string, { bg: string; fg: string }> = {
-  weixin: { bg: 'bg-green-100', fg: 'text-green-600' },
-  shipinhao: { bg: 'bg-green-100', fg: 'text-green-600' },
-  xhs: { bg: 'bg-red-50', fg: 'text-red-500' },
-  doudian: { bg: 'bg-slate-100', fg: 'text-slate-600' },
-  taobao: { bg: 'bg-orange-100', fg: 'text-orange-600' },
-  qianniu: { bg: 'bg-amber-100', fg: 'text-amber-600' },
-  '3e3e': { bg: 'bg-indigo-100', fg: 'text-indigo-600' },
+  weixin: { bg: 'bg-gradient-to-br from-green-100 to-emerald-50', fg: 'text-green-600' },
+  shipinhao: { bg: 'bg-gradient-to-br from-green-100 to-emerald-50', fg: 'text-green-600' },
+  xhs: { bg: 'bg-gradient-to-br from-red-100 to-pink-50', fg: 'text-red-500' },
+  doudian: { bg: 'bg-gradient-to-br from-slate-100 to-indigo-50', fg: 'text-[#4158d0]' },
+  taobao: { bg: 'bg-gradient-to-br from-orange-100 to-pink-50', fg: 'text-orange-600' },
+  qianniu: { bg: 'bg-gradient-to-br from-amber-100 to-orange-50', fg: 'text-amber-600' },
+  '3e3e': { bg: 'bg-gradient-to-br from-indigo-100 to-purple-50', fg: 'text-[#4158d0]' },
 };
 
 export default function Platforms() {
@@ -50,38 +50,38 @@ export default function Platforms() {
       <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-6">
         {platforms.map((p) => {
           const Icon = PLATFORM_ICONS[p.code] || ShoppingBag;
-          const colors = ICON_COLORS[p.code] || { bg: 'bg-gray-100', fg: 'text-gray-600' };
+          const colors = ICON_COLORS[p.code] || { bg: 'bg-gradient-to-br from-indigo-100 to-purple-50', fg: 'text-[#4158d0]' };
           const expired = !p.login_active;
 
           return (
             <div
               key={p.code}
-              className={`bg-white rounded-xl border shadow-sm flex flex-col hover:border-blue-200 transition-colors relative overflow-hidden ${
-                expired ? 'border-red-200' : 'border-gray-200'
+              className={`dd-card relative flex flex-col overflow-hidden transition hover:-translate-y-0.5 hover:shadow-[0_14px_34px_rgba(65,88,208,0.12)] ${
+                expired ? 'border-red-200' : ''
               }`}
             >
               {expired && (
-                <div className="absolute top-0 right-0 bg-red-500 text-white text-[10px] font-bold px-3 py-1 rounded-bl-lg shadow">
+                <div className="absolute right-0 top-0 rounded-bl-lg bg-red-500 px-3 py-1 text-[10px] font-bold text-white shadow">
                   未登录
                 </div>
               )}
 
-              <div className="p-5 flex items-center gap-3 border-b border-gray-50">
-                <div className={`w-12 h-12 rounded-full ${colors.bg} flex items-center justify-center`}>
+              <div className="flex items-center gap-3 border-b border-[rgba(199,210,254,0.55)] bg-gradient-to-r from-[rgba(65,88,208,0.06)] to-[rgba(200,80,192,0.05)] p-5">
+                <div className={`flex h-12 w-12 items-center justify-center rounded-2xl ${colors.bg}`}>
                   <Icon size={24} className={colors.fg} />
                 </div>
-                <div className="font-bold text-lg">{p.name}</div>
+                <div className="text-lg font-black text-neutral-800">{p.name}</div>
               </div>
 
               <div className="p-5 flex-1 space-y-4">
                 <div>
                   <div className="text-xs text-gray-400 mb-1">当前状态</div>
                   {p.login_active ? (
-                    <span className="px-2 py-1 bg-green-50 text-green-700 border border-green-100 rounded-full text-xs font-medium flex items-center gap-1 w-max">
+                    <span className="dd-badge dd-badge-success w-max">
                       <CheckCircle2 size={12} /> 授权有效
                     </span>
                   ) : (
-                    <span className="px-2 py-1 bg-red-50 text-red-700 border border-red-100 rounded-full text-xs font-medium flex items-center gap-1 w-max">
+                    <span className="dd-badge dd-badge-danger w-max">
                       <XCircle size={12} /> 登录已过期
                     </span>
                   )}
@@ -98,14 +98,14 @@ export default function Platforms() {
                 {p.login_active ? (
                   <button
                     onClick={() => handleLogin(p)}
-                    className="w-full py-2 bg-white border border-gray-200 text-slate-700 rounded-lg text-sm font-medium hover:bg-gray-50 flex justify-center items-center gap-2"
+                    className="dd-button-soft w-full gap-2"
                   >
                     <RefreshCw size={16} /> 重新授权
                   </button>
                 ) : (
                   <button
                     onClick={() => handleLogin(p)}
-                    className="w-full py-2 bg-slate-900 text-white rounded-lg text-sm font-medium hover:bg-slate-800 flex justify-center items-center gap-2 shadow-sm"
+                    className="dd-button w-full gap-2"
                   >
                     <QrCode size={16} /> 扫码登录
                   </button>
@@ -118,26 +118,26 @@ export default function Platforms() {
 
       {/* QR Code Login Modal */}
       {qrModal && (
-        <div className="fixed inset-0 bg-slate-900/60 backdrop-blur-sm flex items-center justify-center z-50">
-          <div className="bg-white rounded-2xl shadow-2xl w-[400px] overflow-hidden relative">
+        <div className="dd-overlay fixed inset-0 z-50 flex items-center justify-center">
+          <div className="dd-modal relative w-[400px] overflow-hidden">
             <div className="absolute top-4 right-4">
-              <button onClick={() => setQrModal(null)} className="text-gray-400 hover:text-gray-600 bg-gray-100/50 p-1.5 rounded-full">
+              <button onClick={() => setQrModal(null)} className="dd-close-button">
                 <X size={20} />
               </button>
             </div>
             <div className="p-8 pt-10 flex flex-col items-center">
-              <div className={`w-12 h-12 ${ICON_COLORS[qrModal.code]?.bg || 'bg-gray-100'} rounded-full flex items-center justify-center mb-4`}>
-                {(() => { const I = PLATFORM_ICONS[qrModal.code] || ShoppingBag; return <I size={24} className={ICON_COLORS[qrModal.code]?.fg || 'text-gray-600'} />; })()}
+              <div className={`w-12 h-12 ${ICON_COLORS[qrModal.code]?.bg || 'bg-gradient-to-br from-indigo-100 to-purple-50'} rounded-full flex items-center justify-center mb-4`}>
+                {(() => { const I = PLATFORM_ICONS[qrModal.code] || ShoppingBag; return <I size={24} className={ICON_COLORS[qrModal.code]?.fg || 'text-[#4158d0]'} />; })()}
               </div>
               <h3 className="font-bold text-xl mb-1">登录 {qrModal.name}</h3>
               <p className="text-sm text-gray-500 mb-6 text-center">请在弹出的浏览器窗口中完成扫码登录</p>
 
-              <div className="w-48 h-48 border-2 border-dashed border-gray-300 rounded-2xl bg-gray-50 flex flex-col items-center justify-center mb-6">
-                <QrCode size={40} className="text-gray-300 mb-2" />
+              <div className="mb-6 flex h-48 w-48 flex-col items-center justify-center rounded-2xl border-2 border-dashed border-[rgba(199,210,254,0.9)] bg-gradient-to-br from-white to-[#f6f4ff]">
+                <QrCode size={40} className="mb-2 text-[#756aff]/45" />
                 <span className="text-xs text-gray-400">浏览器已弹出...</span>
               </div>
 
-              <div className="flex items-center gap-2 text-sm text-blue-600 font-medium bg-blue-50 px-4 py-2 rounded-full">
+              <div className="dd-badge dd-badge-info flex items-center gap-2 px-4 py-2 text-sm">
                 {loading === qrModal.code ? (
                   <><Loader2 size={16} className="animate-spin" /> 等待扫码确认...</>
                 ) : (

--- a/web/src/pages/Products.tsx
+++ b/web/src/pages/Products.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
-import { Search, Send, Image, ChevronLeft, ChevronRight, X, ImageIcon, Tag, Ruler, Palette, ShieldCheck, Shirt, Sparkles, Sun } from 'lucide-react';
+import { Search, Send, Image, ChevronLeft, ChevronRight, ImageIcon, Tag, Ruler, Palette, ShieldCheck, Shirt, Sparkles, Sun } from 'lucide-react';
 import { getProducts, createUploadTask, getPlatforms, type Product, type Platform } from '../api/client';
 
 const SOURCES = ['', 'tmall', '3e3e', 'taobao'];
@@ -61,36 +61,36 @@ export default function Products() {
     <div className="space-y-4 relative">
       {/* Floating batch action bar */}
       <div
-        className={`fixed left-1/2 -translate-x-1/2 top-20 bg-slate-900 text-white px-5 py-3 rounded-full shadow-xl flex items-center gap-4 z-20 transition-all duration-300 ${
-          selected.size > 0 ? 'opacity-100 translate-y-0' : 'opacity-0 pointer-events-none -translate-y-4'
+        className={`fixed left-1/2 top-20 z-20 flex -translate-x-1/2 items-center gap-4 rounded-full border border-[rgba(199,210,254,0.7)] bg-white/90 px-5 py-3 text-neutral-800 shadow-[0_16px_42px_rgba(65,88,208,0.16)] backdrop-blur transition-all duration-300 ${
+          selected.size > 0 ? 'translate-y-0 opacity-100' : 'pointer-events-none -translate-y-4 opacity-0'
         }`}
       >
-        <span className="text-sm font-medium">已选择 {selected.size} 项商品</span>
-        <div className="h-4 w-px bg-slate-700" />
+        <span className="text-sm font-semibold">已选择 {selected.size} 项商品</span>
+        <div className="h-4 w-px bg-indigo-100" />
         <button
           onClick={() => setShowPublish(true)}
-          className="text-sm bg-white text-slate-900 px-4 py-1.5 rounded-full font-semibold hover:bg-gray-100 transition-colors flex items-center gap-1"
+          className="dd-button gap-1 transition-colors"
         >
           <Send size={14} /> 批量上架到...
         </button>
       </div>
 
       {/* Toolbar */}
-      <div className="bg-white p-4 rounded-xl border border-gray-200 shadow-sm flex justify-between items-center">
+      <div className="dd-panel flex items-center justify-between p-4">
         <div className="flex gap-3">
           <div className="relative">
-            <Search size={16} className="absolute left-3 top-2.5 text-gray-400" />
+            <Search size={16} className="absolute left-3 top-3 text-neutral-400" />
             <input
               value={search}
               onChange={(e) => { setSearch(e.target.value); setPage(1); }}
               placeholder="搜索商品标题..."
-              className="pl-9 pr-4 py-2 border border-gray-200 rounded-lg text-sm w-64 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 transition-shadow"
+              className="dd-input w-72 py-2 pl-9 pr-4 text-sm"
             />
           </div>
           <select
             value={source}
             onChange={(e) => { setSource(e.target.value); setPage(1); }}
-            className="px-3 py-2 border border-gray-200 rounded-lg text-sm bg-white focus:outline-none focus:border-blue-500"
+            className="dd-select px-4 text-sm"
           >
             {SOURCES.map((s) => <option key={s} value={s}>{s || '全部来源平台'}</option>)}
           </select>
@@ -98,41 +98,41 @@ export default function Products() {
       </div>
 
       {/* Table */}
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+      <div className="dd-table">
         <table className="w-full text-left border-collapse">
-          <thead className="bg-gray-50/80 border-b border-gray-200">
+          <thead>
             <tr>
               <th className="p-4 w-12 text-center">
                 <input type="checkbox" checked={selected.size === items.length && items.length > 0} onChange={toggleAll} className="w-4 h-4 rounded border-gray-300 text-blue-600 cursor-pointer" />
               </th>
-              <th className="p-4 text-xs font-semibold text-gray-500 uppercase">图片</th>
-              <th className="p-4 text-xs font-semibold text-gray-500 uppercase">商品标题</th>
-              <th className="p-4 text-xs font-semibold text-gray-500 uppercase">价格</th>
-              <th className="p-4 text-xs font-semibold text-gray-500 uppercase">来源</th>
-              <th className="p-4 text-xs font-semibold text-gray-500 uppercase">采集时间</th>
+              <th className="p-4 text-xs font-extrabold text-neutral-500 uppercase">图片</th>
+              <th className="p-4 text-xs font-extrabold text-neutral-500 uppercase">商品标题</th>
+              <th className="p-4 text-xs font-extrabold text-neutral-500 uppercase">价格</th>
+              <th className="p-4 text-xs font-extrabold text-neutral-500 uppercase">来源</th>
+              <th className="p-4 text-xs font-extrabold text-neutral-500 uppercase">采集时间</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-100">
+          <tbody>
             {items.map((item) => (
-              <tr key={item.id} className="hover:bg-gray-50/50 transition-colors cursor-pointer" onDoubleClick={() => setDetailProduct(item)}>
+              <tr key={item.id} className="cursor-pointer" onDoubleClick={() => setDetailProduct(item)}>
                 <td className="p-4 text-center">
                   <input type="checkbox" checked={selected.has(item.id)} onChange={() => toggleSelect(item.id)} className="w-4 h-4 rounded border-gray-300 text-blue-600 cursor-pointer" />
                 </td>
                 <td className="p-4">
-                  <div className="w-10 h-10 bg-gray-100 rounded-md border border-gray-200 flex items-center justify-center">
-                    <Image size={16} className="text-gray-400" />
+                  <div className="flex h-10 w-10 items-center justify-center rounded-xl border border-[rgba(199,210,254,0.65)] bg-gradient-to-br from-white to-[#f6f4ff]">
+                    <Image size={16} className="text-[#756aff]" />
                   </div>
                 </td>
-                <td className="p-4 font-medium text-sm text-gray-800 max-w-md truncate">{item.title || '—'}</td>
-                <td className="p-4 text-sm text-red-600 font-semibold">¥ {item.price || '—'}</td>
+                <td className="p-4 max-w-md truncate text-sm font-semibold text-neutral-800">{item.title || '—'}</td>
+                <td className="p-4 text-sm font-bold text-red-600">¥ {item.price || '—'}</td>
                 <td className="p-4">
-                  <span className="px-2 py-1 bg-orange-50 text-orange-600 border border-orange-100 rounded text-xs">{item.source}</span>
+                  <span className="dd-badge dd-badge-warning">{item.source}</span>
                 </td>
                 <td className="p-4 text-sm text-gray-500">{item.crawled_at ? new Date(item.crawled_at).toLocaleString('zh-CN') : '—'}</td>
               </tr>
             ))}
             {items.length === 0 && (
-              <tr><td colSpan={6} className="p-16 text-center text-gray-400">暂无商品数据</td></tr>
+              <tr><td colSpan={6} className="p-8"><div className="dd-empty p-10 text-center text-sm">暂无商品数据</div></td></tr>
             )}
           </tbody>
         </table>
@@ -141,13 +141,13 @@ export default function Products() {
       {/* Pagination */}
       {totalPages > 1 && (
         <div className="flex items-center justify-between">
-          <span className="text-sm text-gray-500">共 {total} 条</span>
+          <span className="text-sm font-medium text-neutral-500">共 {total} 条</span>
           <div className="flex gap-2">
-            <button disabled={page <= 1} onClick={() => setPage(page - 1)} className="p-2 rounded-lg border border-gray-200 disabled:opacity-30 hover:bg-gray-50">
+            <button disabled={page <= 1} onClick={() => setPage(page - 1)} className="dd-button-soft dd-icon-button disabled:opacity-30">
               <ChevronLeft size={16} />
             </button>
-            <span className="px-3 py-2 text-sm text-gray-600">{page} / {totalPages}</span>
-            <button disabled={page >= totalPages} onClick={() => setPage(page + 1)} className="p-2 rounded-lg border border-gray-200 disabled:opacity-30 hover:bg-gray-50">
+            <span className="inline-flex h-11 min-w-[88px] items-center justify-center rounded-full border border-[rgba(199,210,254,0.68)] bg-white/75 px-4 text-sm font-bold text-neutral-600">{page} / {totalPages}</span>
+            <button disabled={page >= totalPages} onClick={() => setPage(page + 1)} className="dd-button-soft dd-icon-button disabled:opacity-30">
               <ChevronRight size={16} />
             </button>
           </div>
@@ -156,11 +156,11 @@ export default function Products() {
 
       {/* Product Detail Modal */}
       {detailProduct && (
-        <div className="fixed inset-0 bg-slate-900/50 backdrop-blur-sm flex items-center justify-center z-50" onClick={() => setDetailProduct(null)}>
-          <div className="bg-white rounded-2xl shadow-2xl w-[600px] max-h-[85vh] overflow-hidden flex flex-col" onClick={(e) => e.stopPropagation()}>
-            <div className="px-6 py-4 border-b border-gray-100 flex justify-between items-center bg-gray-50/50 shrink-0">
+        <div className="dd-overlay fixed inset-0 z-50 flex items-center justify-center" onClick={() => setDetailProduct(null)}>
+          <div className="dd-modal flex max-h-[85vh] w-[600px] flex-col overflow-hidden" onClick={(e) => e.stopPropagation()}>
+            <div className="flex shrink-0 items-center justify-between border-b border-[rgba(199,210,254,0.55)] bg-gradient-to-r from-[rgba(65,88,208,0.07)] to-[rgba(200,80,192,0.06)] px-6 py-4">
               <h3 className="font-bold text-lg truncate pr-4">{detailProduct.title || '未命名商品'}</h3>
-              <button onClick={() => setDetailProduct(null)} className="text-gray-400 hover:text-gray-600 text-xl shrink-0">✕</button>
+              <button onClick={() => setDetailProduct(null)} className="dd-close-button shrink-0">✕</button>
             </div>
             <div className="p-6 space-y-5 overflow-y-auto">
               {/* 基本信息 */}
@@ -171,11 +171,11 @@ export default function Products() {
                 </div>
                 <div className="flex items-center gap-2">
                   <span className="text-gray-500">来源</span>
-                  <span className="px-2 py-0.5 bg-orange-50 text-orange-600 border border-orange-100 rounded text-xs">{detailProduct.source}</span>
+                  <span className="dd-badge dd-badge-warning py-0.5">{detailProduct.source}</span>
                 </div>
                 <div className="flex items-center gap-2">
                   <span className="text-gray-500">状态</span>
-                  <span className="px-2 py-0.5 bg-blue-50 text-blue-600 border border-blue-100 rounded text-xs">{detailProduct.status}</span>
+                  <span className="dd-badge dd-badge-info py-0.5">{detailProduct.status}</span>
                 </div>
                 <div className="flex items-center gap-2">
                   <span className="text-gray-500">采集时间</span>
@@ -191,10 +191,10 @@ export default function Products() {
 
               {/* 图片统计 */}
               <div>
-                <h4 className="text-sm font-semibold text-gray-700 mb-3">图片统计</h4>
+                <h4 className="mb-3 text-sm font-bold text-neutral-700">图片统计</h4>
                 <div className="grid grid-cols-2 gap-3">
-                  <div className="flex items-center gap-3 p-3 bg-blue-50/50 border border-blue-100 rounded-lg">
-                    <div className="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center">
+                  <div className="dd-card flex items-center gap-3 p-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-[rgba(65,88,208,0.14)] to-[rgba(200,80,192,0.14)]">
                       <ImageIcon size={20} className="text-blue-600" />
                     </div>
                     <div>
@@ -202,8 +202,8 @@ export default function Products() {
                       <div className="text-lg font-bold text-gray-800">{countImages(detailProduct.main_images)} <span className="text-sm font-normal text-gray-500">张</span></div>
                     </div>
                   </div>
-                  <div className="flex items-center gap-3 p-3 bg-purple-50/50 border border-purple-100 rounded-lg">
-                    <div className="w-10 h-10 bg-purple-100 rounded-lg flex items-center justify-center">
+                  <div className="dd-card flex items-center gap-3 p-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-[rgba(65,88,208,0.14)] to-[rgba(200,80,192,0.14)]">
                       <Palette size={20} className="text-purple-600" />
                     </div>
                     <div>
@@ -216,7 +216,7 @@ export default function Products() {
 
               {/* 商品属性 */}
               <div>
-                <h4 className="text-sm font-semibold text-gray-700 mb-3">商品属性</h4>
+                <h4 className="mb-3 text-sm font-bold text-neutral-700">商品属性</h4>
                 <div className="grid grid-cols-2 gap-2">
                   {([
                     { icon: Sparkles, label: '风格', value: detailProduct.style },
@@ -228,8 +228,8 @@ export default function Products() {
                     { icon: Ruler, label: '身高', value: detailProduct.height },
                     { icon: Tag, label: '适用性别', value: detailProduct.gender },
                   ] as const).map(({ icon: Icon, label, value }) => (
-                    <div key={label} className="flex items-center gap-2 p-2 bg-gray-50 rounded-lg text-sm">
-                      <Icon size={14} className="text-gray-400 shrink-0" />
+                    <div key={label} className="flex items-center gap-2 rounded-xl border border-[rgba(199,210,254,0.45)] bg-white/70 p-2 text-sm">
+                      <Icon size={14} className="shrink-0 text-[#756aff]" />
                       <span className="text-gray-500 shrink-0">{label}</span>
                       <span className="text-gray-800 truncate">{value || '—'}</span>
                     </div>
@@ -237,8 +237,8 @@ export default function Products() {
                 </div>
               </div>
             </div>
-            <div className="px-6 py-4 bg-gray-50 border-t border-gray-100 flex justify-end shrink-0">
-              <button onClick={() => setDetailProduct(null)} className="px-4 py-2 bg-white border border-gray-300 rounded-lg text-sm font-medium hover:bg-gray-100 text-gray-700">关闭</button>
+            <div className="flex shrink-0 justify-end border-t border-[rgba(199,210,254,0.55)] bg-white/70 px-6 py-4">
+              <button onClick={() => setDetailProduct(null)} className="dd-button-soft">关闭</button>
             </div>
           </div>
         </div>
@@ -246,13 +246,13 @@ export default function Products() {
 
       {/* Publish Modal */}
       {showPublish && (
-        <div className="fixed inset-0 bg-slate-900/50 backdrop-blur-sm flex items-center justify-center z-50">
-          <div className="bg-white rounded-2xl shadow-2xl w-[500px] overflow-hidden">
-            <div className="px-6 py-4 border-b border-gray-100 flex justify-between items-center bg-gray-50/50">
+        <div className="dd-overlay fixed inset-0 z-50 flex items-center justify-center">
+          <div className="dd-modal w-[500px] overflow-hidden">
+            <div className="flex items-center justify-between border-b border-[rgba(199,210,254,0.55)] bg-gradient-to-r from-[rgba(65,88,208,0.07)] to-[rgba(200,80,192,0.06)] px-6 py-4">
               <h3 className="font-bold text-lg flex items-center gap-2">
                 <CloudUploadIcon /> 配置上架任务
               </h3>
-              <button onClick={() => setShowPublish(false)} className="text-gray-400 hover:text-gray-600 text-xl">✕</button>
+              <button onClick={() => setShowPublish(false)} className="dd-close-button">✕</button>
             </div>
             <div className="p-6 space-y-5">
               <div>
@@ -264,12 +264,12 @@ export default function Products() {
                     return (
                       <label
                         key={p.code}
-                        className={`flex items-center gap-2 p-2.5 border rounded-lg text-sm font-medium transition-colors relative overflow-hidden ${
+                        className={`relative flex items-center gap-2 overflow-hidden rounded-2xl border p-3 text-sm font-semibold transition-colors ${
                           disabled
-                            ? 'border-gray-100 bg-gray-50 cursor-not-allowed text-gray-400'
+                            ? 'cursor-not-allowed border-[rgba(203,213,225,0.7)] bg-slate-50/70 text-slate-400'
                             : checked
-                              ? 'border-blue-200 bg-blue-50/30 cursor-pointer hover:bg-blue-50'
-                              : 'border-gray-200 cursor-pointer hover:bg-gray-50'
+                              ? 'cursor-pointer border-[rgba(117,106,255,0.5)] bg-[rgba(117,106,255,0.08)] text-[#4158d0] hover:bg-[rgba(117,106,255,0.12)]'
+                              : 'cursor-pointer border-[rgba(199,210,254,0.75)] bg-white/80 hover:bg-[rgba(65,88,208,0.04)]'
                         }`}
                       >
                         <input
@@ -297,7 +297,7 @@ export default function Products() {
                   <select
                     value={scheduleMode}
                     onChange={(e) => setScheduleMode(e.target.value)}
-                    className="w-1/2 border border-gray-300 rounded-lg p-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className="dd-select w-1/2 px-4 text-sm"
                   >
                     <option value="immediate">立即上架</option>
                     <option value="once">定时上架</option>
@@ -307,18 +307,18 @@ export default function Products() {
                       type="datetime-local"
                       value={scheduledAt}
                       onChange={(e) => setScheduledAt(e.target.value)}
-                      className="w-1/2 border border-gray-300 rounded-lg p-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-600"
+                      className="dd-input w-1/2 px-4 text-sm text-gray-600"
                     />
                   )}
                 </div>
               </div>
             </div>
-            <div className="px-6 py-4 bg-gray-50 border-t border-gray-100 flex justify-end gap-3">
-              <button onClick={() => setShowPublish(false)} className="px-4 py-2 bg-white border border-gray-300 rounded-lg text-sm font-medium hover:bg-gray-100 text-gray-700">取消</button>
+            <div className="flex justify-end gap-3 border-t border-[rgba(199,210,254,0.55)] bg-white/70 px-6 py-4">
+              <button onClick={() => setShowPublish(false)} className="dd-button-soft">取消</button>
               <button
                 onClick={handlePublish}
                 disabled={selectedPlatforms.size === 0}
-                className="px-4 py-2 bg-slate-900 text-white rounded-lg text-sm font-medium hover:bg-slate-800 shadow-sm disabled:opacity-50"
+                className="dd-button disabled:opacity-50"
               >
                 确认上架
               </button>

--- a/web/src/pages/Tasks.tsx
+++ b/web/src/pages/Tasks.tsx
@@ -71,17 +71,13 @@ export default function Tasks() {
   return (
     <div className="space-y-4">
       {/* Header */}
-      <div className="flex justify-between items-center">
-        <div className="bg-gray-200/60 p-1 rounded-lg flex gap-1">
+      <div className="flex items-center justify-between">
+        <div className="dd-tabs">
           {tabs.map((t) => (
             <button
               key={t.key}
               onClick={() => { setFilter(t.key); setExpandedId(null); }}
-              className={`px-4 py-1.5 rounded-md text-sm font-medium transition-all ${
-                filter === t.key
-                  ? 'bg-white text-slate-900 shadow font-semibold'
-                  : 'text-gray-500 hover:text-slate-900'
-              }`}
+              className={`dd-nav-button ${filter === t.key ? 'dd-tab-active' : ''}`}
             >
               {t.label}
             </button>
@@ -90,30 +86,30 @@ export default function Tasks() {
         <div className="flex gap-3">
           <button
             onClick={() => setShowScrape(true)}
-            className="bg-white border border-gray-200 text-slate-900 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-50 flex items-center gap-2 shadow-sm"
+            className="dd-button-soft gap-2"
           >
             <CloudDownload size={16} /> 新建采集任务
           </button>
-          <button className="bg-slate-900 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-slate-800 flex items-center gap-2 shadow-sm">
+          <button className="dd-button gap-2">
             <CloudUpload size={16} /> 新建上架任务
           </button>
         </div>
       </div>
 
       {/* Task Table */}
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+      <div className="dd-table">
         <table className="w-full text-left border-collapse">
-          <thead className="bg-gray-50/80 border-b border-gray-200">
+          <thead>
             <tr>
-              <th className="p-4 w-12 text-center text-gray-400 text-xs font-semibold uppercase">详情</th>
-              <th className="p-4 text-xs font-semibold text-gray-500 uppercase">任务类型</th>
-              <th className="p-4 text-xs font-semibold text-gray-500 uppercase">状态</th>
-              <th className="p-4 text-xs font-semibold text-gray-500 uppercase">创建时间</th>
-              <th className="p-4 text-xs font-semibold text-gray-500 uppercase w-[300px]">进度完成情况</th>
-              <th className="p-4 text-xs font-semibold text-gray-500 uppercase w-20">操作</th>
+              <th className="p-4 w-16 whitespace-nowrap text-center text-[#756aff]/60 text-xs font-extrabold uppercase">详情</th>
+              <th className="p-4 text-xs font-extrabold text-neutral-500 uppercase">任务类型</th>
+              <th className="p-4 text-xs font-extrabold text-neutral-500 uppercase">状态</th>
+              <th className="p-4 text-xs font-extrabold text-neutral-500 uppercase">创建时间</th>
+              <th className="p-4 text-xs font-extrabold text-neutral-500 uppercase w-[300px]">进度完成情况</th>
+              <th className="p-4 text-xs font-extrabold text-neutral-500 uppercase w-20">操作</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-100">
+          <tbody>
             {items.map((task) => {
               const expanded = expandedId === task.id;
               const successCount = task.items.filter((i) => i.status === 'success').length;
@@ -134,7 +130,7 @@ export default function Tasks() {
               );
             })}
             {items.length === 0 && (
-              <tr><td colSpan={6} className="p-16 text-center text-gray-400">暂无任务</td></tr>
+              <tr><td colSpan={6} className="p-8"><div className="dd-empty p-10 text-center text-sm">暂无任务</div></td></tr>
             )}
           </tbody>
         </table>
@@ -142,13 +138,13 @@ export default function Tasks() {
 
       {/* Create Scrape Modal */}
       {showScrape && (
-        <div className="fixed inset-0 bg-slate-900/50 backdrop-blur-sm flex items-center justify-center z-50">
-          <div className="bg-white rounded-2xl shadow-2xl w-[500px] overflow-hidden">
-            <div className="px-6 py-4 border-b border-gray-100 flex justify-between items-center bg-gray-50/50">
+        <div className="dd-overlay fixed inset-0 z-50 flex items-center justify-center">
+          <div className="dd-modal w-[500px] overflow-hidden">
+            <div className="flex items-center justify-between border-b border-[rgba(199,210,254,0.55)] bg-gradient-to-r from-[rgba(65,88,208,0.07)] to-[rgba(200,80,192,0.06)] px-6 py-4">
               <h3 className="font-bold text-lg flex items-center gap-2">
                 <CloudDownload size={20} className="text-orange-500" /> 新建采集任务
               </h3>
-              <button onClick={() => setShowScrape(false)} className="text-gray-400 hover:text-gray-600 text-xl">✕</button>
+              <button onClick={() => setShowScrape(false)} className="dd-close-button">✕</button>
             </div>
             <div className="p-6 space-y-5">
               <div>
@@ -169,7 +165,7 @@ export default function Tasks() {
                   <textarea
                     value={urlText}
                     onChange={(e) => setUrlText(e.target.value)}
-                    className="w-full border border-gray-300 rounded-lg p-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 h-32 resize-none"
+                    className="dd-input h-32 w-full resize-none rounded-2xl p-3 text-sm"
                     placeholder="每行输入一个商品URL..."
                   />
                 </div>
@@ -179,7 +175,7 @@ export default function Tasks() {
                   <input
                     value={feishuUrl}
                     onChange={(e) => setFeishuUrl(e.target.value)}
-                    className="w-full border border-gray-300 rounded-lg p-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className="dd-input w-full px-4 text-sm"
                     placeholder="https://feishu.cn/base/xxxxx"
                   />
                 </div>
@@ -188,7 +184,7 @@ export default function Tasks() {
               <div className="flex gap-3">
                 <div className="flex-1">
                   <label className="block text-sm font-medium text-gray-700 mb-2">来源平台</label>
-                  <select value={crawlSource} onChange={(e) => setCrawlSource(e.target.value)} className="w-full border border-gray-300 rounded-lg p-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+                  <select value={crawlSource} onChange={(e) => setCrawlSource(e.target.value)} className="dd-select w-full px-4 text-sm">
                     <option value="tmall">天猫</option>
                     <option value="taobao">淘宝</option>
                     <option value="3e3e">3e3e</option>
@@ -196,7 +192,7 @@ export default function Tasks() {
                 </div>
                 <div className="flex-1">
                   <label className="block text-sm font-medium text-gray-700 mb-2">执行方式</label>
-                  <select value={scheduleType} onChange={(e) => setScheduleType(e.target.value)} className="w-full border border-gray-300 rounded-lg p-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+                  <select value={scheduleType} onChange={(e) => setScheduleType(e.target.value)} className="dd-select w-full px-4 text-sm">
                     <option value="immediate">立即执行</option>
                     <option value="once">定时执行</option>
                     <option value="cron">周期执行</option>
@@ -205,15 +201,15 @@ export default function Tasks() {
               </div>
 
               {scheduleType === 'once' && (
-                <input type="datetime-local" value={scheduledAt} onChange={(e) => setScheduledAt(e.target.value)} className="w-full border border-gray-300 rounded-lg p-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                <input type="datetime-local" value={scheduledAt} onChange={(e) => setScheduledAt(e.target.value)} className="dd-input w-full px-4 text-sm" />
               )}
               {scheduleType === 'cron' && (
-                <input value={cronExpr} onChange={(e) => setCronExpr(e.target.value)} placeholder="0 10 * * *  （每天10:00）" className="w-full border border-gray-300 rounded-lg p-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                <input value={cronExpr} onChange={(e) => setCronExpr(e.target.value)} placeholder="0 10 * * *  （每天10:00）" className="dd-input w-full px-4 text-sm" />
               )}
             </div>
-            <div className="px-6 py-4 bg-gray-50 border-t border-gray-100 flex justify-end gap-3">
-              <button onClick={() => setShowScrape(false)} className="px-4 py-2 bg-white border border-gray-300 rounded-lg text-sm font-medium hover:bg-gray-100 text-gray-700">取消</button>
-              <button onClick={handleCreate} className="px-4 py-2 bg-slate-900 text-white rounded-lg text-sm font-medium hover:bg-slate-800 shadow-sm">创建任务</button>
+            <div className="flex justify-end gap-3 border-t border-[rgba(199,210,254,0.55)] bg-white/70 px-6 py-4">
+              <button onClick={() => setShowScrape(false)} className="dd-button-soft">取消</button>
+              <button onClick={handleCreate} className="dd-button">创建任务</button>
             </div>
           </div>
         </div>
@@ -227,11 +223,11 @@ function TaskRow({ task, expanded, progress, successCount, totalCount, onToggle,
   onToggle: () => void; onCancel: () => void;
 }) {
   const statusMap: Record<string, { label: string; color: string; icon: typeof Check }> = {
-    pending: { label: '等待中', color: 'text-yellow-700 bg-yellow-50 border-yellow-100', icon: Loader2 },
-    running: { label: '执行中', color: 'text-blue-700 bg-blue-50 border-blue-100', icon: Loader2 },
-    done: { label: '已完成', color: 'text-green-700 bg-green-50 border-green-100', icon: Check },
-    failed: { label: '失败', color: 'text-red-700 bg-red-50 border-red-100', icon: XCircle },
-    cancelled: { label: '已取消', color: 'text-gray-500 bg-gray-50 border-gray-200', icon: X },
+    pending: { label: '等待中', color: 'dd-badge-warning', icon: Loader2 },
+    running: { label: '执行中', color: 'dd-badge-info', icon: Loader2 },
+    done: { label: '已完成', color: 'dd-badge-success', icon: Check },
+    failed: { label: '失败', color: 'dd-badge-danger', icon: XCircle },
+    cancelled: { label: '已取消', color: 'dd-badge-muted', icon: X },
   };
   const st = statusMap[task.status] || statusMap.pending;
   const isRunning = task.status === 'running';
@@ -239,41 +235,41 @@ function TaskRow({ task, expanded, progress, successCount, totalCount, onToggle,
 
   return (
     <>
-      <tr className="hover:bg-gray-50/50 cursor-pointer transition-colors" onClick={onToggle}>
+      <tr className="cursor-pointer" onClick={onToggle}>
         <td className="p-4 text-center">
-          <ChevronDown size={20} className={`text-gray-400 transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`} />
+          <ChevronDown size={20} className={`text-[#756aff]/65 transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`} />
         </td>
         <td className="p-4">
-          <span className={`px-2.5 py-1 rounded text-xs font-medium border ${task.type === 'crawl' ? 'bg-orange-50 text-orange-700 border-orange-100' : 'bg-purple-50 text-purple-700 border-purple-100'}`}>
+          <span className={`dd-badge ${task.type === 'crawl' ? 'dd-badge-warning' : 'dd-badge-gradient'}`}>
             {task.type === 'crawl' ? '数据采集' : '批量上架'}
           </span>
         </td>
         <td className="p-4">
-          <span className={`px-2.5 py-1 rounded-full text-xs font-medium border flex w-max items-center gap-1.5 ${st.color}`}>
+          <span className={`dd-badge flex w-max items-center gap-1.5 ${st.color}`}>
             {isRunning ? <Loader2 size={12} className="animate-spin" /> : <st.icon size={12} />}
             {st.label}
           </span>
         </td>
-        <td className="p-4 text-sm text-gray-600">{new Date(task.created_at).toLocaleString('zh-CN')}</td>
+        <td className="p-4 text-sm font-medium text-neutral-600">{new Date(task.created_at).toLocaleString('zh-CN')}</td>
         <td className="p-4">
           <div className="flex items-center gap-3">
-            <div className="flex-1 h-2 bg-gray-100 rounded-full overflow-hidden">
+            <div className="h-2 flex-1 overflow-hidden rounded-full bg-[rgba(199,210,254,0.45)]">
               <div className={`h-full ${barColor} rounded-full transition-all`} style={{ width: `${progress}%` }} />
             </div>
-            <span className="text-xs font-medium text-gray-500 w-14 text-right">{successCount} / {totalCount}</span>
+            <span className="w-14 text-right text-xs font-semibold text-neutral-500">{successCount} / {totalCount}</span>
           </div>
         </td>
         <td className="p-4">
           {(task.status === 'pending' || task.status === 'running') && (
-            <button onClick={(e) => { e.stopPropagation(); onCancel(); }} className="text-xs text-red-500 hover:text-red-700 font-medium">取消</button>
+            <button onClick={(e) => { e.stopPropagation(); onCancel(); }} className="dd-button-soft !h-8 !min-h-8 !min-w-[64px] !px-3 text-xs !text-red-500 hover:!text-red-700">取消</button>
           )}
         </td>
       </tr>
       {expanded && (
-        <tr className="bg-slate-50">
+        <tr className="bg-[rgba(246,244,255,0.72)]">
           <td colSpan={6} className="p-0">
-            <div className="px-14 py-4 border-b border-gray-200">
-              <div className="text-xs font-semibold text-gray-500 mb-3 tracking-wider">执行日志明细</div>
+            <div className="border-b border-[rgba(199,210,254,0.55)] px-14 py-4">
+              <div className="mb-3 text-xs font-extrabold tracking-wider text-neutral-500">执行日志明细</div>
               <div className="space-y-2 text-sm">
                 {task.items.map((item) => (
                   <div key={item.id} className="flex items-center gap-2 text-gray-700">

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -6,10 +6,12 @@ import tailwindcss from '@tailwindcss/vite'
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
+    host: '127.0.0.1',
     port: 5173,
+    strictPort: true,
     proxy: {
-      '/api': 'http://localhost:8000',
-      '/ws': { target: 'ws://localhost:8000', ws: true },
+      '/api': 'http://127.0.0.1:8000',
+      '/ws': { target: 'ws://127.0.0.1:8000', ws: true },
     },
   },
 })


### PR DESCRIPTION
## Summary
- 统一商品分发顶部三端导航，与工作台、图片优化保持一致
- 统一按钮、卡片、表格、弹窗、表单等基础视觉样式
- 调整任务、仪表盘、商品、平台页面的前端展示风格，不改业务接口和路由结构

## Test plan
- [x] npm run build --prefix C:/Users/Administrator/Desktop/luffy0211/web
- [ ] 打开 http://127.0.0.1:5173 检查任务管理页面
- [ ] 检查 /dashboard、/products、/platforms 页面样式和路由
- [ ] 检查工作台、图片优化、商品分发三端跳转

🤖 Generated with [Claude Code](https://claude.com/claude-code)